### PR TITLE
改进了choosespeakers模块

### DIFF
--- a/组会排序/doschedules.py
+++ b/组会排序/doschedules.py
@@ -4,7 +4,9 @@ from tools import sendwechat, choosespeaker
 
 
 def job():
-    sendwechat.send_chatrooms_msg(choosespeaker.make_decisions(), '马欢')
+    speaker = choosespeaker.make_decisions()
+    print('下周组会轮到你：%s' % speaker)
+    sendwechat.send_chatrooms_msg('下周组会轮到你：%s@%s' % (speaker, speaker), '马欢')
 
 
 schedule.every(5).seconds.do(job)

--- a/组会排序/doschedules.py
+++ b/组会排序/doschedules.py
@@ -4,9 +4,12 @@ from tools import sendwechat, choosespeaker
 
 
 def job():
-    speaker = choosespeaker.make_decisions()
+    """每周运行一次，选出本周speaker，一轮之中不出现重复speaker；对于两轮之间，同一个speaker两次之间至少隔两周"""
+    choosespeaker.read_config('members.ini')
+    speaker = choosespeaker.choose_speaker()
     print('下周组会轮到你：%s' % speaker)
     sendwechat.send_chatrooms_msg('下周组会轮到你：%s@%s' % (speaker, speaker), '马欢')
+    choosespeaker.save_data()
 
 
 schedule.every(5).seconds.do(job)


### PR DESCRIPTION
分析这个模块的应用场景，发现对于外部用户来说，其实只有三件事是重点：
 - 打开members文件并读取数据
 - 随机选出报告人
 - 保存数据到members文件

因此，我对choosespeakers模块进行了改进，采用了”单例模式(Singleton pattern)“的设计模式，精炼到只剩下三个最有用的函数
 - read_config
 - choose_speaker
 - save_data

这使模块的可用性和扩展性更强，而外部用户的使用过程也会更加清晰：
```python
# main.py
from tools import choosespeaker
choosespeaker.read_config('members.ini')
print(choosespeaker.choose_speaker())
choosespeaker.save_data()
```
另外，在外部调用help(choosespeaker)也可以得到更清晰的帮助文档